### PR TITLE
prince-archiver: Provide region name to s3

### DIFF
--- a/prince-archiver/prince_archiver/config.py
+++ b/prince-archiver/prince_archiver/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     AWS_SECRET_ACCESS_KEY: str
     AWS_BUCKET_NAME: str
     AWS_ENDPOINT_URL: str | None = None
+    AWS_REGION_NAME: str | None = None
 
     DATA_DIR: Path
     ARCHIVE_DIR: Path

--- a/prince-archiver/prince_archiver/worker.py
+++ b/prince-archiver/prince_archiver/worker.py
@@ -90,10 +90,15 @@ async def workflow(ctx: dict, input_data: dict):
 async def managed_file_system(
     settings: Settings,
 ) -> AsyncGenerator[s3fs.S3FileSystem, None]:
+    client_kwargs = {}
+    if settings.AWS_REGION_NAME:
+        client_kwargs["region_name"] = settings.AWS_REGION_NAME
+
     s3 = s3fs.S3FileSystem(
         key=settings.AWS_ACCESS_KEY_ID,
         secret=settings.AWS_SECRET_ACCESS_KEY,
         endpoint_url=settings.AWS_ENDPOINT_URL,
+        client_kwargs=client_kwargs,
         asynchronous=True,
     )
 


### PR DESCRIPTION
## Description

AWS region name required for compatibility with openstack swift. 

## Implementation
- `AWS_REGION_NAME` added as optional setting and provided to s3fs client when needed