### PR TITLE
DA-54 surf-archiver: Update path regex

### DIFF
--- a/surf-archiver/pyproject.toml
+++ b/surf-archiver/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "surf-archiver"
-version = "0.1.1a0"
+version = "0.1.1a1"
 description = ""
 authors = ["Isaac Williams <isaac.andrew.williams@gmail.com>"]
 readme = "README.md"

--- a/surf-archiver/surf_archiver/file.py
+++ b/surf-archiver/surf_archiver/file.py
@@ -42,7 +42,7 @@ class ExperimentFileSystem:
         date_prefix = date.strftime("%Y%m%d")
 
         files = await self.s3._glob(
-            f"{self.bucket_name}/{mode}/*/{date_prefix}*.tar",
+            f"{self.bucket_name}/{mode}/*/{date_prefix}/*.tar",
         )
         return self._group_files(files)
 
@@ -67,7 +67,7 @@ class ExperimentFileSystem:
     def _group_files(files: list[str]) -> dict[str, list[str]]:
         data: dict[str, list[str]] = defaultdict(list)
         for file_obj, file in zip(map(Path, files), files):
-            data[file_obj.parent.name].append(file)
+            data[file_obj.parent.parent.name].append(file)
         return data
 
 

--- a/surf-archiver/tests/integration/test_cli.py
+++ b/surf-archiver/tests/integration/test_cli.py
@@ -13,7 +13,7 @@ from surf_archiver.test_utils import MessageWaiter
 @pytest.fixture(name="object_store_data")
 def fixture_object_store_data(random_str: str):
     bucket_url = f"http://localhost:9091/{random_str}"
-    file_url = f"{bucket_url}/images/test-id/20000101_0000.tar"
+    file_url = f"{bucket_url}/images/test-id/20000101/0000.tar"
 
     with Client() as client:
         client.put(bucket_url)

--- a/surf-archiver/tests/unit/test_archiver.py
+++ b/surf-archiver/tests/unit/test_archiver.py
@@ -13,7 +13,7 @@ from surf_archiver.file import ArchiveFileSystem, ExperimentFileSystem
 def fixture_experiment_file_system() -> ExperimentFileSystem:
     file_system = AsyncMock(ExperimentFileSystem)
     file_system.list_files_by_date.return_value = {
-        "test-id": ["test-bucket/images/test-id/20000101_0000.tar"],
+        "test-id": ["test-bucket/images/test-id/20000101/0000.tar"],
     }
     return file_system
 
@@ -38,7 +38,7 @@ async def test_new_files_are_archived(
     expected = [
         ArchiveEntry(
             path="images/test-id/2000-01-01.tar",
-            src_keys=["test-bucket/images/test-id/20000101_0000.tar"],
+            src_keys=["test-bucket/images/test-id/20000101/0000.tar"],
         )
     ]
 

--- a/surf-archiver/tests/unit/test_experiment_file_system.py
+++ b/surf-archiver/tests/unit/test_experiment_file_system.py
@@ -9,18 +9,18 @@ from surf_archiver.file import ExperimentFileSystem
 async def test_list_files_by_date():
     mock_s3 = AsyncMock(S3FileSystem)
     mock_s3._glob.return_value = [
-        "test-bucket/images/id-1/20000101_0000.tar",
-        "test-bucket/images/id-2/20000101_0000.tar",
-        "test-bucket/images/id-2/20000101_0100.tar",
+        "test-bucket/images/id-1/20000101/0000.tar",
+        "test-bucket/images/id-2/20000101/0000.tar",
+        "test-bucket/images/id-2/20000101/0100.tar",
     ]
 
     file_system = ExperimentFileSystem(s3=mock_s3, bucket_name="test-bucket")
 
     expected = {
-        "id-1": ["test-bucket/images/id-1/20000101_0000.tar"],
+        "id-1": ["test-bucket/images/id-1/20000101/0000.tar"],
         "id-2": [
-            "test-bucket/images/id-2/20000101_0000.tar",
-            "test-bucket/images/id-2/20000101_0100.tar",
+            "test-bucket/images/id-2/20000101/0000.tar",
+            "test-bucket/images/id-2/20000101/0100.tar",
         ],
     }
 


### PR DESCRIPTION
## Description
Latest changes in `prince-archiver` resulted in changes to the object storage key structure. These need to be reflected in `surf-archiver`

## Implementation
- `f"{self.bucket_name}/{mode}/*/{date_prefix}*.tar"` -> `f"{self.bucket_name}/{mode}/*/{date_prefix}/*.tar"`
- bump version