### PR TITLE
DA-57: Reduce CPU usage

### DIFF
--- a/prince-archiver/prince_archiver/adapters/streams.py
+++ b/prince-archiver/prince_archiver/adapters/streams.py
@@ -91,7 +91,8 @@ class Stream:
                 groupname=group.group_name,
                 consumername=group.consumer_name,
                 streams={self.stream: stream_id},
-                count=1,
+                count=5,
+                block=2000,
             )
 
             # Occurs when there are no latest messages (e.g >)


### PR DESCRIPTION
## Description
Extremely high CPU usage by containers, as `block` not being set when redis stream is being read.

## Implementation
- Set `block=2000` (ms)
