### PR TITLE
DA-61 surf-archiver: Ensure that subscriber keeps references

### DIFF
--- a/prince-archiver/compose.dev.yml
+++ b/prince-archiver/compose.dev.yml
@@ -85,7 +85,10 @@ services:
       interval: 5s
       timeout: 5s
       retries: 3
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
 
 
 volumes:
   input_data:
+  rabbitmq_data:

--- a/prince-archiver/prince_archiver/adapters/subscriber.py
+++ b/prince-archiver/prince_archiver/adapters/subscriber.py
@@ -4,7 +4,13 @@ from dataclasses import dataclass
 from typing import Awaitable, Callable
 
 from aio_pika import ExchangeType, connect_robust
-from aio_pika.abc import AbstractIncomingMessage
+from aio_pika.abc import (
+    AbstractIncomingMessage,
+    AbstractQueue,
+    AbstractRobustChannel,
+    AbstractRobustConnection,
+    AbstractRobustExchange,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -15,44 +21,54 @@ class ExchangeConfig:
     type: ExchangeType = ExchangeType.FANOUT
 
 
+@dataclass
+class QueueConfig:
+    name: str | None = "state-manager"
+    durable: bool = True
+
+
 class ManagedSubscriber:
     def __init__(
         self,
         connection_url: str,
         message_handler: Callable[[AbstractIncomingMessage], Awaitable[None]],
         exchange_config: ExchangeConfig | None = None,
+        queue_config: QueueConfig | None = None,
     ):
         self.connection_url = connection_url
         self.exchange_config = exchange_config or ExchangeConfig()
+        self.queue_config = queue_config or QueueConfig()
+
         self.message_handler = message_handler
 
         self.exit_stack: AsyncExitStack | None = None
 
+        self.connection: AbstractRobustConnection | None
+        self.exchange: AbstractRobustExchange | None
+        self.channel: AbstractRobustChannel | None = None
+        self.queue: AbstractQueue | None = None
+
     async def __aenter__(self):
         self.exit_stack = await AsyncExitStack().__aenter__()
 
-        connection = await connect_robust(self.connection_url)
-        await self.exit_stack.enter_async_context(connection)
+        self.connection = await connect_robust(self.connection_url)
+        await self.exit_stack.enter_async_context(self.connection)
 
-        channel = await connection.channel()
-        await channel.set_qos(prefetch_count=1)
+        self.channel = await self.connection.channel()
+        await self.channel.set_qos(prefetch_count=1)
 
-        exchange = await channel.declare_exchange(
+        self.exchange = await self.channel.declare_exchange(
             self.exchange_config.name,
             self.exchange_config.type,
         )
 
-        queue = await channel.declare_queue(
-            durable=True,
-            exclusive=True,
+        self.queue = await self.channel.declare_queue(
+            self.queue_config.name,
+            durable=self.queue_config.durable,
         )
 
-        await queue.bind(exchange)
-        await queue.consume(self.message_handler)
-
-        LOGGER.info("Subscribed to channel")
-
-        return self
+        await self.queue.bind(self.exchange)
+        await self.queue.consume(self.message_handler)
 
     async def __aexit__(self, exc_type, exc_value, exc_tb):
         if self.exit_stack:

--- a/prince-archiver/tests/integration/test_subscriber.py
+++ b/prince-archiver/tests/integration/test_subscriber.py
@@ -7,7 +7,11 @@ from aio_pika import Message, connect
 from aio_pika.abc import AbstractConnection, AbstractExchange, AbstractIncomingMessage
 from testcontainers.rabbitmq import RabbitMqContainer
 
-from prince_archiver.adapters.subscriber import ExchangeConfig, ManagedSubscriber
+from prince_archiver.adapters.subscriber import (
+    ExchangeConfig,
+    ManagedSubscriber,
+    QueueConfig,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -81,6 +85,10 @@ async def test_managed_subscriber(
         url,
         message_handler=message_handler,
         exchange_config=exchange_config,
+        queue_config=QueueConfig(
+            name=None,
+            durable=False,
+        ),
     )
     async with subscriber:
         message_body = uuid4().hex.encode()


### PR DESCRIPTION
## Description
Underlying `queue` needs to be kept as strong reference in order to ensure that `consume` method is robust. If not, the queue bind gets lost on reconnection


## Implementation
- Add `QueueConfig` class
- Cache `connection`, `channel`, `exchange` and `queue` on class
