### PR TITLE
DA-70: User outerjoin

### DIFF
--- a/prince-archiver/prince_archiver/entrypoints/api/models.py
+++ b/prince-archiver/prince_archiver/entrypoints/api/models.py
@@ -58,8 +58,8 @@ class ArchiveMemberModel(BaseModel):
     member_key: str
     ref_id: UUID
     timestamp: datetime
-    checksum: str
-    size: int
+    checksum: str | None
+    size: int | None
 
 
 class ArchiveModel(BaseArchiveModel):

--- a/prince-archiver/prince_archiver/models/read/archive_member.py
+++ b/prince-archiver/prince_archiver/models/read/archive_member.py
@@ -30,8 +30,8 @@ class ArchiveMember(ReadBase):
         )
         .join_from(DataArchiveMember, ObjectStoreEntry)
         .join_from(ObjectStoreEntry, ImagingEvent)
-        .join_from(ImagingEvent, EventArchive)
-        .join_from(EventArchive, ArchiveChecksum)
+        .outerjoin_from(ImagingEvent, EventArchive)
+        .outerjoin_from(EventArchive, ArchiveChecksum)
         .subquery()
     )
 


### PR DESCRIPTION
## Description
Use outerjoin in read models as checksum and size have not always been stored.


## Implementation
- User outerjoins for `ImagingEvent` -> `EventArchive` and `EventArchive` -> `ArchiveChecksum`
- Ensure api model fields accept optional