### PR TITLE
DA-68: Improve stats model

### DIFF
--- a/prince-archiver/compose.dev.yml
+++ b/prince-archiver/compose.dev.yml
@@ -53,6 +53,8 @@ services:
     environment:
       <<: *aws-env-variables
     <<: *code-volumes
+    ports:
+      - 127.0.0.1:8000:8000
 
   prestart:
     <<: *code-volumes

--- a/prince-archiver/compose.dev.yml
+++ b/prince-archiver/compose.dev.yml
@@ -53,8 +53,6 @@ services:
     environment:
       <<: *aws-env-variables
     <<: *code-volumes
-    ports:
-      - 127.0.0.1:8000:8000
 
   prestart:
     <<: *code-volumes

--- a/prince-archiver/prince_archiver/entrypoints/mock_prince/cli.py
+++ b/prince-archiver/prince_archiver/entrypoints/mock_prince/cli.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 import typer
 
 from prince_archiver.definitions import System
-from prince_archiver.service_layer.external_dto import TimestepMeta
+from prince_archiver.service_layer.external_dto import TimestepDTO
 from prince_archiver.test_utils.utils import make_timestep_directory
 from prince_archiver.utils import now
 
@@ -27,7 +27,7 @@ def make_timestep_dir(
     data_dir: DataDirT,
     timestamp: Annotated[datetime, typer.Option(default_factory=now)],
 ):
-    meta = TimestepMeta(
+    meta = TimestepDTO(
         plate=1,
         cross_date=date(2000, 1, 1),
         position=1,

--- a/prince-archiver/prince_archiver/entrypoints/mock_prince/main.py
+++ b/prince-archiver/prince_archiver/entrypoints/mock_prince/main.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI, Response
 from pydantic_settings import BaseSettings
 
 from prince_archiver.log import configure_logging
-from prince_archiver.service_layer.external_dto import TimestepMeta
+from prince_archiver.service_layer.external_dto import TimestepDTO
 from prince_archiver.test_utils.utils import make_timestep_directory
 from prince_archiver.utils import now
 
@@ -21,8 +21,8 @@ class Settings(BaseSettings):
     DATA_DIR: Path
 
 
-def _create_meta() -> TimestepMeta:
-    return TimestepMeta(
+def _create_meta() -> TimestepDTO:
+    return TimestepDTO(
         plate=1,
         cross_date=date(2000, 1, 1),
         position=1,
@@ -37,7 +37,7 @@ def create_app(*, settings: Settings | None = None) -> FastAPI:
     settings = settings or Settings()
 
     @app.post("/timestep", status_code=200)
-    def create_timestep(data: TimestepMeta) -> Response:
+    def create_timestep(data: TimestepDTO) -> Response:
         logging.info("[%s] Added timestep", data.timestep_id)
         make_timestep_directory(meta=data, base_dir=settings.DATA_DIR)
         return Response(status_code=200)

--- a/prince-archiver/prince_archiver/models/read/stats.py
+++ b/prince-archiver/prince_archiver/models/read/stats.py
@@ -1,67 +1,35 @@
 from datetime import date
 
-from sqlalchemy import Subquery, func, select
-from sqlalchemy.orm import InstrumentedAttribute, Mapped
+from sqlalchemy import Select, case, func, select
+from sqlalchemy.orm import Mapped
 
 from prince_archiver.models.v2 import DataArchiveMember, ImagingEvent, ObjectStoreEntry
 
 from .utils import ReadBase
 
 
-def query_builder() -> Subquery:
-    """
-    Build subquery to be passed into `DailyStats` model.
-    """
-
-    def build_count_subquery(
-        field: InstrumentedAttribute,
-        count_label: str,
-    ) -> Subquery:
-        _date_field = func.date(field).label("date")
-        return (
-            select(_date_field, func.count(_date_field).label(count_label))
-            .group_by(_date_field)
-            .subquery()
-        )
-
-    event_count = build_count_subquery(ImagingEvent.timestamp, "event_count")
-    upload_count = build_count_subquery(ObjectStoreEntry.uploaded_at, "export_count")
-    archive_count = build_count_subquery(DataArchiveMember.created_at, "archive_count")
-
-    t1 = (
+def query_builder() -> Select:
+    subquery = (
         select(
-            func.coalesce(event_count.c.date, upload_count.c.date).label("date"),
-            event_count.c.event_count,
-            upload_count.c.export_count,
+            ImagingEvent.id,
+            func.date(ImagingEvent.timestamp).label("date"),
+            case((ObjectStoreEntry.id.is_(None), 0), else_=1).label("is_exported"),
+            case((DataArchiveMember.id.is_(None), 0), else_=1).label("is_archived"),
         )
-        .join_from(
-            event_count,
-            upload_count,
-            onclause=event_count.c.date == upload_count.c.date,
-            full=True,
-        )
+        .outerjoin_from(ImagingEvent, ObjectStoreEntry)
+        .outerjoin_from(ObjectStoreEntry, DataArchiveMember)
         .subquery()
     )
-
-    return (
-        select(
-            func.coalesce(t1.c.date, archive_count.c.date).label("date"),
-            func.coalesce(t1.c.event_count, 0).label("event_count"),
-            func.coalesce(t1.c.export_count, 0).label("export_count"),
-            func.coalesce(archive_count.c.archive_count, 0).label("archive_count"),
-        )
-        .join_from(
-            t1,
-            archive_count,
-            onclause=t1.c.date == archive_count.c.date,
-            full=True,
-        )
-        .subquery()
-    )
+    return select(
+        subquery.c.date,
+        func.count().label("event_count"),
+        func.sum(subquery.c.is_exported).label("export_count"),
+        func.sum(subquery.c.is_archived).label("archive_count"),
+    ).group_by(subquery.c.date)
 
 
 class DailyStats(ReadBase):
-    __table__ = query_builder()
+    __table__ = query_builder().subquery()
     __mapper_args__ = {"primary_key": __table__.c.date}
 
     date: Mapped[date]

--- a/prince-archiver/prince_archiver/service_layer/external_dto.py
+++ b/prince-archiver/prince_archiver/service_layer/external_dto.py
@@ -1,6 +1,6 @@
 """Definition of data transfer objects."""
 
-from datetime import UTC, date
+from datetime import date
 from pathlib import Path
 from uuid import UUID, uuid4
 
@@ -9,7 +9,7 @@ from pydantic import AwareDatetime, BaseModel, Field, model_validator
 from prince_archiver.definitions import EventType, System
 
 
-class TimestepMeta(BaseModel):
+class TimestepDTO(BaseModel):
     timestep_id: UUID = Field(default_factory=uuid4)
     plate: int
     cross_date: date
@@ -23,22 +23,10 @@ class TimestepMeta(BaseModel):
     img_dir: Path = Field(..., alias="path")
 
     @model_validator(mode="after")
-    def set_experiment_id(self) -> "TimestepMeta":
+    def set_experiment_id(self) -> "TimestepDTO":
         if not self.experiment_id:
             cross_date = self.cross_date.strftime("%Y%m%d")
             self.experiment_id = f"{cross_date}_{self.plate:03d}"
-        return self
-
-
-class TimestepDTO(TimestepMeta):
-    key: str = Field(default_factory=str)
-
-    @model_validator(mode="after")
-    def set_key(self) -> "TimestepDTO":
-        if not self.key:
-            ts = self.timestamp.astimezone(UTC)
-            root = ts.strftime("%Y%m%d_%H%M.tar")
-            self.key = f"{self.experiment_id}/{root}"
         return self
 
 

--- a/prince-archiver/prince_archiver/service_layer/handlers/utils.py
+++ b/prince-archiver/prince_archiver/service_layer/handlers/utils.py
@@ -1,6 +1,4 @@
-from typing import Any
-
-from pydantic import BaseModel
+from datetime import UTC
 
 from prince_archiver.definitions import EventType
 from prince_archiver.service_layer.messages import ExportImagingEvent
@@ -8,20 +6,12 @@ from prince_archiver.service_layer.messages import ExportImagingEvent
 
 def get_target_key(imaging_event: ExportImagingEvent, bucket: str) -> str:
     event_type = "images" if imaging_event.type == EventType.STITCH else "videos"
-    date_folder = imaging_event.timestamp.strftime("%Y%m%d")
-    file_name = imaging_event.timestamp.strftime("%H%M%S.tar")
+
+    ref_timestamp = imaging_event.timestamp.astimezone(UTC)
+
+    date_folder = ref_timestamp.strftime("%Y%m%d")
+    file_name = ref_timestamp.strftime("%H%M%S.tar")
 
     return "/".join(
         (bucket, event_type, imaging_event.experiment_id, date_folder, file_name)
     )
-
-
-def model_to_dict(
-    model: BaseModel,
-    *,
-    exclude: set[str] | None = None,
-) -> dict[str, Any]:
-    model_as_dict = dict(model)
-    if exclude:
-        return {k: v for k, v in model_as_dict.items() if k not in exclude}
-    return model_as_dict

--- a/prince-archiver/prince_archiver/service_layer/messages.py
+++ b/prince-archiver/prince_archiver/service_layer/messages.py
@@ -1,8 +1,7 @@
-from datetime import datetime
 from pathlib import Path
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field, AwareDatetime
+from pydantic import AwareDatetime, BaseModel, Field
 
 from prince_archiver.definitions import Algorithm, EventType, System
 from prince_archiver.utils import now

--- a/prince-archiver/prince_archiver/service_layer/messages.py
+++ b/prince-archiver/prince_archiver/service_layer/messages.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from pathlib import Path
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, AwareDatetime
 
 from prince_archiver.definitions import Algorithm, EventType, System
 from prince_archiver.utils import now
@@ -11,7 +11,7 @@ from prince_archiver.utils import now
 class CommonImagingEvent(BaseModel):
     ref_id: UUID
     experiment_id: str
-    timestamp: datetime
+    timestamp: AwareDatetime
     type: EventType = Field(default=EventType.STITCH)
     system: System = Field(default=System.PRINCE)
 
@@ -52,7 +52,7 @@ class ExportedImagingEvent(BaseModel):
     checksum: Checksum
     size: int
     key: str
-    timestamp: datetime = Field(default_factory=now)
+    timestamp: AwareDatetime = Field(default_factory=now)
 
 
 # Relating to data archive

--- a/prince-archiver/prince_archiver/test_utils/utils.py
+++ b/prince-archiver/prince_archiver/test_utils/utils.py
@@ -5,7 +5,7 @@ from timeit import default_timer
 
 import httpx
 
-from prince_archiver.service_layer.external_dto import TimestepMeta
+from prince_archiver.service_layer.external_dto import TimestepDTO
 
 DOWNLOAD_URL = "https://vu.data.surfsara.nl/index.php/s/ndI1UoMRwliVYGR/download"
 
@@ -26,7 +26,7 @@ def _get_image(url: str = DOWNLOAD_URL):
 
 
 def make_timestep_directory(
-    meta: TimestepMeta,
+    meta: TimestepDTO,
     base_dir: Path,
     src_img: Path | None = None,
 ) -> None:

--- a/prince-archiver/tests/e2e/steps/upload.py
+++ b/prince-archiver/tests/e2e/steps/upload.py
@@ -10,7 +10,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from prince_archiver.definitions import EventType
-from prince_archiver.service_layer.external_dto import TimestepMeta
+from prince_archiver.service_layer.external_dto import TimestepDTO
 from prince_archiver.test_utils.utils import Timer
 
 
@@ -25,7 +25,7 @@ def step_impl(context):
 
     context.timestep_id = uuid4()
 
-    meta = TimestepMeta(
+    meta = TimestepDTO(
         timestep_id=context.timestep_id,
         plate=1,
         cross_date=date(2000, 1, 1),

--- a/prince-archiver/tests/integration/test_read_models.py
+++ b/prince-archiver/tests/integration/test_read_models.py
@@ -52,25 +52,11 @@ async def test_data_archive_member_model(session: AsyncSession):
 
 
 @pytest.mark.usefixtures("seed_data")
-async def test_model_contruction(session: AsyncSession):
-    result = await session.scalars(select(DailyStats))
-    entries = result.all()
+async def test_daily_stats_model(session: AsyncSession):
+    result = await session.scalar(select(DailyStats))
 
-    assert len(entries) == 3
-
-    first, second, third = sorted(entries, key=lambda item: item.date)
-
-    assert first.date == date(2000, 1, 1)
-    assert first.event_count == 1
-    assert first.export_count == 0
-    assert first.archive_count == 0
-
-    assert second.date == date(2001, 1, 1)
-    assert second.event_count == 0
-    assert second.export_count == 1
-    assert second.archive_count == 0
-
-    assert third.date == date(2002, 1, 1)
-    assert third.event_count == 0
-    assert third.export_count == 0
-    assert third.archive_count == 1
+    assert result
+    assert result.date == date(2000, 1, 1)
+    assert result.event_count == 1
+    assert result.export_count == 1
+    assert result.archive_count == 1

--- a/prince-archiver/tests/unit/test_external_dto.py
+++ b/prince-archiver/tests/unit/test_external_dto.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 import pytest
 
-from prince_archiver.service_layer.external_dto import TimestepDTO, TimestepMeta
+from prince_archiver.service_layer.external_dto import TimestepDTO
 
 
 @dataclass
@@ -25,11 +25,5 @@ def fixture_base_kwargs() -> _BaseKwargs:
 
 
 def test_experiment_id_set(base_kwargs: _BaseKwargs):
-    dto = TimestepMeta(**base_kwargs.__dict__)
+    dto = TimestepDTO(**base_kwargs.__dict__)
     assert dto.experiment_id == "20000101_001"
-
-
-def test_key_set(base_kwargs: _BaseKwargs):
-    dto = TimestepDTO(experiment_id="test-id", **base_kwargs.__dict__)
-
-    assert dto.key == "test-id/20010101_0000.tar"


### PR DESCRIPTION
## Description
Use timestamp of imaging event as basis of calculating stats model.


## Implementation
- Outer join `ImagingEvent` on `ObjectStoreEntry` and `DataArchiveMember`
- Group by `date` which is derived from imaging event timestamp
