### PR TITLE
DA-76: Write metadata to file

### DIFF
--- a/prince-archiver/prince_archiver/adapters/file/__init__.py
+++ b/prince-archiver/prince_archiver/adapters/file/__init__.py
@@ -1,4 +1,4 @@
-from .file_system import AsyncFileSystem
+from .file_system import AsyncFileSystem, MetaData
 from .integrations import ArchiveFile, ArchiveInfo, SrcDir, SystemDir
 from .path_manager import PathManager
 
@@ -10,4 +10,5 @@ __all__ = (
     "PathManager",
     "SrcDir",
     "SystemDir",
+    "MetaData",
 )

--- a/prince-archiver/prince_archiver/adapters/file/file_system.py
+++ b/prince-archiver/prince_archiver/adapters/file/file_system.py
@@ -106,8 +106,11 @@ class AsyncFileSystem:
             tar.add(src, arcname=".")
 
             if metadata:
+                tar_info = tarfile.TarInfo(metadata.name)
+                tar_info.size = len(metadata.content)
+
                 tar.addfile(
-                    tarfile.TarInfo(metadata.name),
+                    tar_info,
                     io.BytesIO(metadata.content),
                 )
 

--- a/prince-archiver/prince_archiver/adapters/file/integrations.py
+++ b/prince-archiver/prince_archiver/adapters/file/integrations.py
@@ -7,7 +7,7 @@ from typing import AsyncGenerator
 from prince_archiver.definitions import System
 from prince_archiver.domain.value_objects import Checksum
 
-from .file_system import AsyncFileSystem
+from .file_system import AsyncFileSystem, MetaData
 
 
 class SystemDir:
@@ -54,8 +54,13 @@ class SrcDir:
         await self.file_system.rm_tree(self.path)
 
     @asynccontextmanager
-    async def get_temp_archive(self) -> AsyncGenerator["ArchiveFile", None]:
-        async with self.file_system.get_temp_archive(self.path) as path:
+    async def get_temp_archive(
+        self,
+        *,
+        metadata: MetaData | None = None,
+    ) -> AsyncGenerator["ArchiveFile", None]:
+        temp_archive = self.file_system.get_temp_archive(self.path, metadata=metadata)
+        async with temp_archive as path:
             yield ArchiveFile(path, self.file_system)
 
 

--- a/prince-archiver/prince_archiver/entrypoints/mock_prince/main.py
+++ b/prince-archiver/prince_archiver/entrypoints/mock_prince/main.py
@@ -37,6 +37,7 @@ def _create_event() -> ImagingEventStream:
         type=EventType.STITCH,
         system=System.PRINCE,
         img_count=1,
+        metadata={"application": {"application": "mock-prince"}},
         local_path=Path(ref_id.hex[:6]),
     )
 

--- a/prince-archiver/prince_archiver/service_layer/messages.py
+++ b/prince-archiver/prince_archiver/service_layer/messages.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Literal
 from uuid import UUID, uuid4
 
 from pydantic import AwareDatetime, BaseModel, Field, Json
@@ -34,17 +35,26 @@ class ImportedImagingEvent(ImportImagingEvent):
     id: UUID
 
 
+# For exporting out
 class MessageInfo(BaseModel):
     id: str | bytes
     stream_name: str
     group_name: str
 
 
-# For exporting out
 class ExportImagingEvent(CommonImagingEvent):
     local_path: Path
     metadata: dict
     message_info: MessageInfo
+
+
+class BaseSchema(BaseModel):
+    pass
+
+
+class Schema(CommonImagingEvent, BaseSchema):
+    schema_version: Literal["0.1.0a1"] = "0.1.0a1"
+    metadata: dict
 
 
 class Checksum(BaseModel):

--- a/prince-archiver/prince_archiver/service_layer/messages.py
+++ b/prince-archiver/prince_archiver/service_layer/messages.py
@@ -43,6 +43,7 @@ class MessageInfo(BaseModel):
 # For exporting out
 class ExportImagingEvent(CommonImagingEvent):
     local_path: Path
+    metadata: dict
     message_info: MessageInfo
 
 

--- a/prince-archiver/tests/unit/entrypoints/test_upload_worker.py
+++ b/prince-archiver/tests/unit/entrypoints/test_upload_worker.py
@@ -18,6 +18,7 @@ def fixture_workflow_payload():
         "type": EventType.STITCH,
         "system": System.PRINCE,
         "local_path": "test/path",
+        "metadata": {},
         "message_info": {
             "id": "test-id",
             "stream_name": "test-stream",


### PR DESCRIPTION
## Description
Write metadata to file

## Implementation
- Allow metadata to passed into the contruction of the temp archive
- Ensure that the size is added to the `TarInfo` object
