### PR TITLE
DA-89 prince-archiver: Add missing model

### DIFF
--- a/prince-archiver/prince_archiver/service_layer/dto/common.py
+++ b/prince-archiver/prince_archiver/service_layer/dto/common.py
@@ -39,10 +39,16 @@ class Stitching(BaseModel):
     grid_size: tuple[int, int]
 
 
+class Video(BaseModel):
+    duration: int
+    location: tuple[float, float, float]
+
+
 class Metadata(BaseModel):
     application: Application
     camera: Camera
     stitching: Stitching | None = None
+    video: Video | None = None
 
 
 class SrcDirInfo(BaseModel):

--- a/prince-archiver/prince_archiver/service_layer/dto/schema.py
+++ b/prince-archiver/prince_archiver/service_layer/dto/schema.py
@@ -11,5 +11,5 @@ class BaseSchema(BaseModel):
 
 
 class Schema(CommonImagingEvent, BaseSchema):
-    schema_version: Literal["1a0"] = "1a0"
+    schema_version: Literal["1a1"] = "1a1"
     metadata: Metadata


### PR DESCRIPTION
## Description
Add `video` model to metadata.

## Implementation
- Add `video` model to metadata
