### PR TITLE
Video model edit

### DIFF
--- a/prince-archiver/prince_archiver/service_layer/dto/common.py
+++ b/prince-archiver/prince_archiver/service_layer/dto/common.py
@@ -34,6 +34,7 @@ class Camera(BaseModel):
     bits_per_pixel: float
     pixel_size: float | None
 
+
 class Stitching(BaseModel):
     last_focused_at: datetime | None
     grid_size: tuple[int, int]
@@ -45,6 +46,7 @@ class Video(BaseModel):
     magnification: float | None
     type: str | None
     video_nr: int | None
+
 
 class Metadata(BaseModel):
     application: Application

--- a/prince-archiver/prince_archiver/service_layer/dto/common.py
+++ b/prince-archiver/prince_archiver/service_layer/dto/common.py
@@ -32,7 +32,7 @@ class Camera(BaseModel):
     gamma: float | None
     intensity: list[float]
     bits_per_pixel: float
-
+    pixel_size: float | None
 
 class Stitching(BaseModel):
     last_focused_at: datetime | None
@@ -42,8 +42,9 @@ class Stitching(BaseModel):
 class Video(BaseModel):
     duration: int
     location: tuple[float, float, float]
-    magnification: int | None
+    magnification: float | None
     type: str | None
+    video_nr: int | None
 
 class Metadata(BaseModel):
     application: Application

--- a/prince-archiver/prince_archiver/service_layer/dto/common.py
+++ b/prince-archiver/prince_archiver/service_layer/dto/common.py
@@ -32,7 +32,7 @@ class Camera(BaseModel):
     gamma: float | None
     intensity: list[float]
     bits_per_pixel: float
-    pixel_size: float | None
+    pixel_size: float | None = None
 
 
 class Stitching(BaseModel):
@@ -43,9 +43,9 @@ class Stitching(BaseModel):
 class Video(BaseModel):
     duration: int
     location: tuple[float, float, float]
-    magnification: float | None
-    type: str | None
-    video_nr: int | None
+    magnification: float | None = None
+    type: str | None = None
+    video_nr: int | None = None
 
 
 class Metadata(BaseModel):

--- a/prince-archiver/prince_archiver/service_layer/dto/common.py
+++ b/prince-archiver/prince_archiver/service_layer/dto/common.py
@@ -42,7 +42,8 @@ class Stitching(BaseModel):
 class Video(BaseModel):
     duration: int
     location: tuple[float, float, float]
-
+    magnification: int | None
+    type: str | None
 
 class Metadata(BaseModel):
     application: Application


### PR DESCRIPTION
## Description
- Made video model compatible with changes in magnification/video type (BF vs F)
- Added `pixel_size `in camera fields
- Added an optional `video_nr `field to facilitate morrison video registration. For Aretha this is irrelevant.

## Implementation
- Video type now has three new fields: `type `(str equal to "Brightfield" or "Fluorescence" (to double check), `magnification `(float), `video_nr `(int)
- camera now has a `pixel_size `field.
